### PR TITLE
feat: add a new endpoint for deleting product

### DIFF
--- a/gateapi/gateapi/api/routers/product.py
+++ b/gateapi/gateapi/api/routers/product.py
@@ -27,3 +27,15 @@ def create_product(request: schemas.Product, rpc = Depends(get_rpc)):
         return {
             "id": request.id
         }
+    
+
+@router.delete("/{product_id}", status_code=status.HTTP_200_OK)
+def delete_product(product_id: str, rpc = Depends(get_rpc)):
+    try: 
+        with rpc.next() as nameko:
+            return nameko.products.delete(product_id)
+    except ProductNotFound as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(error)
+        )

--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -73,6 +73,16 @@ class GatewayService(object):
         return Response(
             json.dumps({'id': product_data['id']}), mimetype='application/json'
         )
+    
+    @http(
+        "DELETE", "/products/<string:product_id>",
+        expected_exceptions=ProductNotFound
+    )
+    def delete_product(self, request, product_id):
+        """Delete product by `product_id`
+        """
+        result = self.products_rpc.delete(product_id)
+        return Response(result)
 
     @http("GET", "/orders/<int:order_id>", expected_exceptions=OrderNotFound)
     def get_order(self, request, order_id):
@@ -172,3 +182,4 @@ class GatewayService(object):
             serialized_data['order_details']
         )
         return result['id']
+    

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -52,6 +52,13 @@ class StorageWrapper:
         self.client.hmset(
             self._format_key(product['id']),
             product)
+        
+    def delete(self, product_id):
+        result = self.client.delete(self._format_key(product_id))
+        if (result == 0):
+            raise NotFound('Product ID {} does not exist'.format(product_id))
+        else:
+            return "Deleted"
 
     def decrement_stock(self, product_id, amount):
         return self.client.hincrby(

--- a/products/products/service.py
+++ b/products/products/service.py
@@ -30,6 +30,10 @@ class ProductsService:
         product = schemas.Product(strict=True).load(product).data
         self.storage.create(product)
 
+    @rpc
+    def delete(self, product_id):
+        self.storage.delete(product_id)
+
     @event_handler('orders', 'order_created')
     def handle_order_created(self, payload):
         for product in payload['order']['order_details']:

--- a/products/test/test_dependencies.py
+++ b/products/test/test_dependencies.py
@@ -62,3 +62,17 @@ def test_decrement_stock(storage, create_product, redis_client):
     assert b'10' == product_one[b'in_stock']
     assert b'7' == product_two[b'in_stock']
     assert b'12' == product_three[b'in_stock']
+
+def test_delete_fails_on_not_found(storage):
+    with pytest.raises(storage.NotFound) as exc:
+        storage.delete("the_nicolas")
+    assert 'Product ID the_nicolas does not exist' == exc.value.args[0]
+
+def test_delete(storage, create_product):
+    create_product(id=1, title='The Nicolas', in_stock=5)
+    product = storage.get(1)
+    assert product 
+    assert 'The Nicolas' == product['title']
+    storage.delete(1)
+    product = storage.get(1)
+    assert not product

--- a/products/test/test_service.py
+++ b/products/test/test_service.py
@@ -150,3 +150,19 @@ def test_handle_order_created(
     assert b'6' == product_one[b'in_stock']
     assert b'9' == product_two[b'in_stock']
     assert b'12' == product_three[b'in_stock']
+
+def test_delete_product(create_product, service_container):
+
+    stored_product = create_product()
+
+    with entrypoint_hook(service_container, 'delete') as delete:
+        loaded_product = delete(stored_product['id'])
+
+    assert stored_product == loaded_product
+
+
+def test_delete_product_fails_on_not_found(service_container):
+
+    with pytest.raises(NotFound):
+        with entrypoint_hook(service_container, 'delete') as delete:
+            delete("not_valid_id")

--- a/test/nex-bzt.yml
+++ b/test/nex-bzt.yml
@@ -64,6 +64,21 @@ scenarios:
         product_key: $.id
         default: NOT_FOUND
 
+    # 2. Delete Product
+    - url: /products/${product_id}
+      label: product-delete
+      think-time: uniform(0s, 0s)
+      method: DELETE
+        
+      assert:
+      - contains:
+        - 200
+        subject: http-code
+        not: false
+      extract-jsonpath:
+        product_key: $.id
+        default: NOT_FOUND
+
     # 3. Create Orders
     - url: /orders
       label: orders-create

--- a/test/nex-smoketest.sh
+++ b/test/nex-smoketest.sh
@@ -38,6 +38,27 @@ echo
 echo "=== Getting product id: the_odyssey ==="
 curl -s "${STD_APP_URL}/products/the_odyssey" | jq .
 
+# Test: Delete Product
+echo "=== Deleting a product ==="
+echo "#1 Creating a new product id: the_nicolas"
+curl -s -XPOST  "${STD_APP_URL}/products" \
+    -H 'accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d '{"id": "the_nicolas", "title": "The Nicolas", "passenger_capacity": 202, "maximum_speed": 3, "in_stock": 4}'
+
+echo ''
+echo "#2 Checking it was created"
+curl -s "${STD_APP_URL}/products/the_nicolas" | jq .
+
+echo "#3 Deleting a product id: the_nicolas"
+curl -s -XDELETE -I "${STD_APP_URL}/products/the_nicolas"
+
+echo "#4 Checking it was deleted"
+curl -s "${STD_APP_URL}/products/the_nicolas" | jq .
+
+echo
+# Test: Get Product
+
 # Test: Create Order
 echo "=== Creating Order ==="
 ORDER_ID=$(


### PR DESCRIPTION
### Context
Add a new endpoint for deleting products.

**/products/\<product-id>**
- 200: Product exists and was deleted
- 404: Product not exists

### Changes
- Gateway: a new endpoint declaration in the router, and service method.
- Product:  a new method in domain & service layers.

### Tests
- unit tests: add success and fail scenarios for the deleting method in Gateway and Product services.
- smoke-test: a new flow where a new product is recorded and deleted without any side effects in other tests.
- perf-test: new call description for deleting a product.

### Impact
- Product domain
- New public API endpoint exposed.