### PR TITLE
feat: add a new endpoint for listing orders

### DIFF
--- a/gateapi/gateapi/api/routers/order.py
+++ b/gateapi/gateapi/api/routers/order.py
@@ -1,5 +1,5 @@
 from os import name
-from fastapi import APIRouter, status, HTTPException
+from fastapi import APIRouter, status, HTTPException, Query
 from fastapi.params import Depends
 from typing import List
 from gateapi.api import schemas
@@ -10,6 +10,13 @@ router = APIRouter(
     prefix = "/orders",
     tags = ['Orders']
 )
+
+@router.get("", status_code=status.HTTP_200_OK)
+def list(page: int = Query(1, ge=1), 
+         page_size: int = Query(25, ge=0), 
+         rpc = Depends(get_rpc)):
+    with rpc.next() as nameko:
+        return nameko.orders.list(page, page_size)
 
 @router.get("/{order_id}", status_code=status.HTTP_200_OK)
 def get_order(order_id: int, rpc = Depends(get_rpc)):

--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -73,6 +73,16 @@ class GatewayService(object):
         return Response(
             json.dumps({'id': product_data['id']}), mimetype='application/json'
         )
+    
+    @http("GET", "/orders")
+    def list(self, request):
+        page = int(request.values['page'])
+        page_size = int(request.values['page_size'])
+        orders = self.orders_rpc.list(page, page_size)
+        return Response(
+            json.dumps(orders), 
+            mimetype='application/json'
+        )
 
     @http("GET", "/orders/<int:order_id>", expected_exceptions=OrderNotFound)
     def get_order(self, request, order_id):

--- a/orders/orders/service.py
+++ b/orders/orders/service.py
@@ -1,17 +1,34 @@
 from nameko.events import EventDispatcher
 from nameko.rpc import rpc
 from nameko_sqlalchemy import DatabaseSession
-
+from sqlalchemy import select, func
+from math import ceil
 from orders.exceptions import NotFound
 from orders.models import DeclarativeBase, Order, OrderDetail
 from orders.schemas import OrderSchema
-
 
 class OrdersService:
     name = 'orders'
 
     db = DatabaseSession(DeclarativeBase)
     event_dispatcher = EventDispatcher()
+
+    @rpc
+    def list(self, page, page_size):
+        limit = page_size * page
+        offset = (page - 1) * page_size
+
+        total_items = self.db.scalar(select(func.count()).select_from(Order))
+        items = self.db.scalars(
+            select(Order).limit(limit).offset(offset)).all()
+
+        total_pages = (1 if total_items == 0 else ceil(total_items / page_size))
+
+        return {'page': page,
+                'page_size': page_size,
+                'total_items': total_items,
+                'total_pages': total_pages,
+                'items': OrderSchema().dump(items, many=True).data}
 
     @rpc
     def get_order(self, order_id):

--- a/orders/test/interface/test_service.py
+++ b/orders/test/interface/test_service.py
@@ -2,6 +2,7 @@ import pytest
 
 from mock import call
 from nameko.exceptions import RemoteError
+from marshmallow.exceptions import ValidationError
 
 from orders.models import Order, OrderDetail
 from orders.schemas import OrderSchema, OrderDetailSchema
@@ -13,7 +14,6 @@ def order(db_session):
     db_session.add(order)
     db_session.commit()
     return order
-
 
 @pytest.fixture
 def order_details(db_session, order):
@@ -32,7 +32,6 @@ def order_details(db_session, order):
 def test_get_order(orders_rpc, order):
     response = orders_rpc.get_order(1)
     assert response['id'] == order.id
-
 
 @pytest.mark.usefixtures('db_session')
 def test_will_raise_when_order_not_found(orders_rpc):
@@ -94,3 +93,69 @@ def test_can_update_order(orders_rpc, order):
 def test_can_delete_order(orders_rpc, order, db_session):
     orders_rpc.delete_order(order.id)
     assert not db_session.query(Order).filter_by(id=order.id).count()
+
+
+@pytest.fixture
+def orders(db_session):
+    for i in range(0, 10):
+        db_session.add(Order(id=i))
+        db_session.commit()
+    return orders
+
+def test_list_order(orders_rpc, orders):
+    page=1
+    page_size=10
+    response = orders_rpc.list(page, page_size)
+    assert response['page'] == 1
+    assert response['page_size'] == 10
+    assert response['total_pages'] == 1
+    assert response['total_items'] == 10
+    assert len(response['items']) == 10
+
+    page=1
+    page_size=5
+    response = orders_rpc.list(page, page_size)
+    assert response['page'] == 1
+    assert response['page_size'] == 5
+    assert response['total_pages'] == 2
+    assert response['total_items'] == 10
+    assert len(response['items']) == 5
+
+    page=2
+    page_size=5
+    response = orders_rpc.list(page, page_size)
+    assert response['page'] == 2
+    assert response['page_size'] == 5
+    assert response['total_pages'] == 2
+    assert response['total_items'] == 10
+    assert len(response['items']) == 5
+
+    page=4
+    page_size=3
+    response = orders_rpc.list(page, page_size)
+    assert response['page'] == 4
+    assert response['page_size'] == 3
+    assert response['total_pages'] == 4
+    assert response['total_items'] == 10
+    assert len(response['items']) == 1
+
+    # no exists page
+    page=1000
+    page_size=3
+    response = orders_rpc.list(page, page_size)
+    assert response['page'] == 1000
+    assert response['page_size'] == 3
+    assert response['total_pages'] == 4
+    assert response['total_items'] == 10
+    assert len(response['items']) == 0
+
+def test_list_order_no_orders(orders_rpc):
+    page=1
+    page_size=10
+    response = orders_rpc.list(page, page_size)
+    print(response)
+    assert response['page'] == 1
+    assert response['page_size'] == 10
+    assert response['total_pages'] == 1
+    assert response['total_items'] == 0
+    assert len(response['items']) == 0

--- a/test/nex-bzt.yml
+++ b/test/nex-bzt.yml
@@ -108,6 +108,18 @@ scenarios:
     - if: '"${order_id}" == "NOT_FOUND"'
       then:
         - action: continue
+
+    # 5. List Orders
+    - url: /orders?page=1&page_size=25
+      label: order-list
+      think-time: uniform(0s, 0s)
+      method: GET
+        
+      assert:
+      - contains:
+        - 200
+        subject: http-code
+        not: false
   
 reporting:
 - module: final-stats

--- a/test/nex-smoketest.sh
+++ b/test/nex-smoketest.sh
@@ -52,3 +52,7 @@ ID=$(echo ${ORDER_ID} | jq '.id')
 # Test: Get Order back
 echo "=== Getting Order ==="
 curl -s "${STD_APP_URL}/orders/${ID}" | jq .
+
+# Test: List Orders
+echo "=== Listing Orders by pages ==="
+curl -s "${STD_APP_URL}/orders?page=1&page_size=10" | jq .


### PR DESCRIPTION
### Context
Add a new endpoint for listing orders.

**/orders**

- query params required:
  page: int & page_size: int
 i.g. /orders?page=1&page_size=10
- 200: returns a list of orders(it can be empty)


### Changes
- Gateway: a new endpoint declaration in the router, and service method.
- Order:  a new method in domain & service layers.

### Tests
- unit tests: add success scenarios for the listing method in Gateway and Order services.
- smoke-test: a new flow where a list of orders was requested.
- perf-test: new call description for listing orders.

### Impact
- Order Domain
- New public API endpoint exposed.